### PR TITLE
list page, detail page 구현 / 데이터 페칭을 위해 `useFetch` 커스텀 훅 구현 및 캐싱, 자동갱신 기능 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repositorynpx vercel link
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Type check & Build
+        run: |
+          yarn build
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .
+          prod: true

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env
+.vercel

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,7 +1,7 @@
-export const api = {
-  popular: (page = 1, language = 'ko-KR') =>
-    `https://api.themoviedb.org/3/movie/popular?language=${language}&page=${page}`,
+const baseUrl = 'https://api.themoviedb.org/3/movie';
 
-  detail: (id: string, language = 'ko-KR') =>
-    `https://api.themoviedb.org/3/movie/${id}?language=${language}`,
+export const api = {
+  popular: (page = 1, language = 'ko-KR') => `${baseUrl}/popular?language=${language}&page=${page}`,
+
+  detail: (id: string, language = 'ko-KR') => `${baseUrl}/${id}?language=${language}`,
 };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,7 @@
+export const api = {
+  popular: (page = 1, language = 'ko-KR') =>
+    `https://api.themoviedb.org/3/movie/popular?language=${language}&page=${page}`,
+
+  detail: (id: string, language = 'ko-KR') =>
+    `https://api.themoviedb.org/3/movie/${id}?language=${language}`,
+};

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,7 +1,9 @@
-const baseUrl = 'https://api.themoviedb.org/3/movie';
+// const baseUrl = 'https://api.themoviedb.org/3/movie';
+// const BASE_URL = 'https://api.themoviedb.org/3';
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
-export const api = {
-  popular: (page = 1, language = 'ko-KR') => `${baseUrl}/popular?language=${language}&page=${page}`,
-
-  detail: (id: string, language = 'ko-KR') => `${baseUrl}/${id}?language=${language}`,
+export const apis = {
+  // popular: (page = 1, language = 'ko-KR') => `${BASE_URL}/movie/popular?language=${language}&page=${page}`,
+  popular: ({page, language}: {page: number, language: string}) => `${BASE_URL}/movie/popular?language=${language}&page=${page}`,
+  detail: (id: string, {language}: {language: string}) => `${BASE_URL}/movie/${id}?language=${language}`,
 };

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,97 @@
+import { TMDB_BASE_URL } from "@/constant";
+
+interface ApiError extends Error {
+  statusCode?: number;
+  statusText?: string;
+}
+
+export interface ApiResponse<T> {
+  data: T;
+  success: boolean;
+  error?: ApiError;
+}
+
+class ApiClient {
+  private baseUrl: string;
+  private headers: Record<string, string>;
+
+  constructor(baseUrl: string, defaultHeaders: Record<string, string> = {}) {
+    this.baseUrl = baseUrl;
+    this.headers = {
+      'Content-Type': 'application/json',
+      ...defaultHeaders,
+    };
+  }
+
+  private async request<T>(
+    endpoint: string,
+    options: RequestInit = {}
+  ): Promise<ApiResponse<T>> {
+    const url = `${this.baseUrl}${endpoint}`;
+    
+    try {
+      console.log('🚀 API Request:', { url, method: options.method || 'GET' });
+      
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          ...this.headers,
+          ...options.headers,
+        },
+      });
+
+      if (!response.ok) {
+        const error: ApiError = new Error(`API Error: ${response.status}`) as ApiError;
+        error.statusCode = response.status;
+        error.statusText = response.statusText;
+        
+        console.error('❌ API Error:', { url, status: response.status, statusText: response.statusText });
+        
+        return {
+          data: null as T,
+          success: false,
+          error,
+        };
+      }
+
+      const data: T = await response.json();
+      console.log('✅ API Success:', { url, dataKeys: Object.keys(data as object) });
+      
+      return {
+        data,
+        success: true,
+      };
+    } catch (error) {
+      console.error('💥 API Network Error:', { url, error });
+      
+      const apiError: ApiError = error instanceof Error 
+        ? error as ApiError 
+        : new Error('Network error') as ApiError;
+      
+      return {
+        data: null as T,
+        success: false,
+        error: apiError,
+      };
+    }
+  }
+
+  async get<T>(endpoint: string): Promise<ApiResponse<T>> {
+    return this.request<T>(endpoint, { method: 'GET' });
+  }
+
+  async post<T, U = unknown>(
+    endpoint: string,
+    body?: U
+  ): Promise<ApiResponse<T>> {
+    return this.request<T>(endpoint, {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+}
+
+// TMDB API 클라이언트 인스턴스
+export const tmdbClient = new ApiClient(TMDB_BASE_URL, {
+  Authorization: `Bearer blahblahblah access token`,
+}); 

--- a/src/api/movie.ts
+++ b/src/api/movie.ts
@@ -1,0 +1,43 @@
+import { tmdbClient } from './client';
+import type { Movie, MovieDetail } from '../types/movie';
+
+
+
+interface MovieListParams {
+  language?: string;
+  page?: number;
+}
+
+// 쿼리 스트링 빌더 유틸
+const buildQuery = (params: Record<string, string | number | undefined>) => {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      query.append(key, String(value));
+    }
+  });
+  return query.toString();
+};
+
+/**
+ * 인기 영화 목록 조회
+ */
+export const getPopularMovies = async (params: MovieListParams = {}) => {
+  const { language = 'ko-KR', page = 1 } = params;
+  
+  console.log('📽️ Fetching popular movies:', { page, language });
+  
+  const queryString = buildQuery({ language, page });
+  return tmdbClient.get<Movie[]>(`/movie/popular?${queryString}`);
+};
+
+/**
+ * 영화 상세 정보 조회
+ */
+export const getMovieDetail = async (movieId: number, language = 'ko-KR') => {
+  console.log('🎬 Fetching movie detail:', { movieId, language });
+  
+  const queryString = buildQuery({ language });
+  return tmdbClient.get<MovieDetail>(`/movie/${movieId}?${queryString}`);
+};
+

--- a/src/components/MovieCard.tsx
+++ b/src/components/MovieCard.tsx
@@ -1,6 +1,6 @@
 import { StarIcon } from '@heroicons/react/24/solid';
 import { Link } from 'react-router-dom';
-import type { Movie } from '@/types/Movie';
+import type { Movie } from '@/types/movie';
 
 interface MovieCardProps {
   movie: Movie;

--- a/src/components/MovieCard.tsx
+++ b/src/components/MovieCard.tsx
@@ -1,15 +1,9 @@
 import { StarIcon } from '@heroicons/react/24/solid';
 import { Link } from 'react-router-dom';
+import type { Movie } from '@/types/Movie';
 
 interface MovieCardProps {
-  movie: {
-    id: number;
-    title: string;
-    original_title: string;
-    poster_path: string;
-    vote_average: number;
-    release_date: string;
-  };
+  movie: Movie;
 }
 
 export default function MovieCard({ movie }: MovieCardProps) {
@@ -18,7 +12,11 @@ export default function MovieCard({ movie }: MovieCardProps) {
       to={`/movie/${movie.id}`}
       className="block bg-[#1c2a3a] rounded-lg overflow-hidden hover:scale-105 transition"
     >
-      <img src={movie.poster_path} alt={movie.title} className="w-full h-72 object-cover" />
+      <img
+        src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+        alt={movie.title}
+        className="w-full h-72 object-cover"
+      />
       <div className="p-3">
         <h3 className="text-white font-semibold text-sm leading-tight line-clamp-2">
           {movie.title}

--- a/src/components/MovieDetail/MovieDetailSkeleton.tsx
+++ b/src/components/MovieDetail/MovieDetailSkeleton.tsx
@@ -1,0 +1,37 @@
+export default function MovieDetailSkeleton() {
+  return (
+    <div className="bg-[#0d253f] text-white min-h-screen animate-pulse">
+      <div className="relative h-[60vh] w-full overflow-hidden">
+        <div className="w-full h-full bg-white/10" />
+        <div className="absolute inset-0 flex items-end p-8 bg-gradient-to-t from-[#0d253f] to-transparent">
+          <div className="flex gap-8 max-w-6xl w-full mx-auto items-end">
+            <div className="w-40 sm:w-48 h-60 bg-white/10 rounded-lg" />
+            <div className="flex-1 space-y-4">
+              <div className="h-8 bg-white/20 rounded w-2/3" />
+              <div className="h-4 bg-white/10 rounded w-1/2" />
+              <div className="flex gap-4 mt-4">
+                <div className="h-4 w-16 bg-white/10 rounded" />
+                <div className="h-4 w-16 bg-white/10 rounded" />
+                <div className="h-4 w-16 bg-white/10 rounded" />
+              </div>
+              <div className="flex gap-2 mt-3 flex-wrap">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="w-16 h-6 bg-white/10 rounded-full" />
+                ))}
+              </div>
+              <div className="w-32 h-10 bg-white/20 rounded-full mt-5" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <section className="max-w-4xl mx-auto px-6 py-12 space-y-4">
+        <div className="h-6 bg-white/20 rounded w-32" />
+        <div className="h-4 bg-white/10 rounded w-full" />
+        <div className="h-4 bg-white/10 rounded w-11/12" />
+        <div className="h-4 bg-white/10 rounded w-4/5" />
+        <div className="h-4 bg-white/10 rounded w-2/3" />
+      </section>
+    </div>
+  );
+}

--- a/src/components/MovieList/MovieCardSkeleton.tsx
+++ b/src/components/MovieList/MovieCardSkeleton.tsx
@@ -1,0 +1,16 @@
+export default function MovieSkeletonCard() {
+  return (
+    <div className="bg-[#1c2a3a] rounded-lg overflow-hidden animate-pulse">
+      <div className="w-full h-72 bg-white/10" />
+      <div className="p-3 space-y-2">
+        <div className="h-4 bg-white/20 rounded w-full" />
+        <div className="h-4 bg-white/20 rounded w-5/6" />
+        <div className="h-3 bg-white/10 rounded w-1/2" />
+        <div className="flex items-center gap-1 mt-2">
+          <div className="w-4 h-4 bg-white/20 rounded-full" />
+          <div className="h-3 bg-white/10 rounded w-6" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MovieList/MovieListView.tsx
+++ b/src/components/MovieList/MovieListView.tsx
@@ -1,0 +1,43 @@
+import MovieCard from '@/components/MovieCard';
+import MovieSkeletonCard from '@/components/MovieList/MovieCardSkeleton';
+import type { Movie } from '@/types/movie';
+
+interface MovieListViewProps {
+  status: 'idle' | 'loading' | 'error' | 'success';
+  movieList: Movie[];
+}
+
+export default function MovieListView({ status, movieList }: MovieListViewProps) {
+  if (status === 'loading')
+    return (
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+        {Array.from({ length: 10 }).map((_, i) => (
+          <MovieSkeletonCard key={i} />
+        ))}
+      </div>
+    );
+
+  if (status === 'error') {
+    return (
+      <div className="text-red-400 text-center py-10">
+        <p>영화 데이터를 불러오지 못했습니다.</p>
+      </div>
+    );
+  }
+
+  if (movieList.length === 0) {
+    return (
+      <div className="text-center py-10">
+        <p>영화가 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+      {movieList.map((movie) => (
+        <MovieCard key={movie.id} movie={movie} />
+      ))}
+    </div>
+  );
+}

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -1,0 +1,1 @@
+export const TMDB_BASE_URL = 'https://api.themoviedb.org/3';

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,124 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { ApiResponse } from '../api/client';
+
+type ApiStatus = 'idle' | 'loading' | 'success' | 'error';
+
+interface UseApiResult<T> {
+  data: T | null;
+  status: ApiStatus;
+  error: Error | null;
+  refetch: () => void;
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+}
+
+interface UseApiOptions {
+  enabled?: boolean;
+  cacheTime?: number;
+  staleTime?: number;
+}
+
+const cache = new Map<string, { data: unknown; timestamp: number }>();
+
+export function useApi<T>(
+  apiCall: () => Promise<ApiResponse<T>>,
+  cacheKey: string,
+  options: UseApiOptions = {}
+): UseApiResult<T> {
+  const { enabled = true, cacheTime = 5 * 60 * 1000, staleTime = 30 * 1000 } = options;
+  
+  const [data, setData] = useState<T | null>(null);
+  const [status, setStatus] = useState<ApiStatus>('idle');
+  const [error, setError] = useState<Error | null>(null);
+  const [refetchCount, setRefetchCount] = useState(0);
+
+  const refetch = useCallback(() => {
+    console.log('🔄 Refetch triggered for:', cacheKey);
+    setRefetchCount(prev => prev + 1);
+  }, [cacheKey]);
+
+  useEffect(() => {
+    if (!enabled) {
+      console.log('⏸️ API call disabled for:', cacheKey);
+      return;
+    }
+
+    let mounted = true;
+
+    const executeCall = async () => {
+      // 캐시 확인
+      const now = Date.now();
+      const cached = cache.get(cacheKey);
+      
+      if (cached && now - cached.timestamp < staleTime) {
+        console.log('💾 Using cached data for:', cacheKey);
+        setData(cached.data as T);
+        setStatus('success');
+        setError(null);
+        return;
+      }
+
+      setStatus('loading');
+      setError(null);
+      
+      try {
+        console.log('🌐 Executing API call for:', cacheKey);
+        const response = await apiCall();
+        
+        if (!mounted) return;
+
+        if (response.success && response.data) {
+          // 캐시에 저장
+          cache.set(cacheKey, {
+            data: response.data,
+            timestamp: now,
+          });
+          
+          // 캐시 만료 스케줄링
+          setTimeout(() => {
+            console.log('🗑️ Cache expired for:', cacheKey);
+            cache.delete(cacheKey);
+          }, cacheTime);
+
+          setData(response.data);
+          setStatus('success');
+        } else {
+          const apiError = response.error || new Error('Unknown API error');
+          console.error('❌ API call failed for:', cacheKey, apiError);
+          setError(apiError);
+          setStatus('error');
+        }
+      } catch (err) {
+        if (!mounted || (err instanceof DOMException && err.name === 'AbortError')) {
+          return;
+        }
+        
+        const error = err instanceof Error ? err : new Error('Unknown error');
+        console.error('💥 API call error for:', cacheKey, error);
+        setError(error);
+        setStatus('error');
+      }
+    };
+
+    executeCall();
+
+    return () => {
+      mounted = false;
+    };
+  }, [apiCall, cacheKey, enabled, cacheTime, staleTime, refetchCount]);
+
+  const computedStates = useMemo(() => ({
+    isLoading: status === 'loading',
+    isSuccess: status === 'success', 
+    isError: status === 'error',
+  }), [status]);
+
+  return {
+    data,
+    status,
+    error,
+    refetch,
+    ...computedStates
+  };
+} 

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+
+type Status = 'idle' | 'loading' | 'error' | 'success';
+
+interface UseFetchResult<T> {
+  data: T | null;
+  status: Status;
+  error: Error | null;
+}
+
+export function useFetch<T>(url: string, enabled = true): UseFetchResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const controller = new AbortController();
+    const signal = controller.signal;
+    let isMounted = true;
+
+    const fetchData = async () => {
+      setStatus('loading');
+      try {
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            accept: 'application/json',
+            Authorization: `Bearer ${import.meta.env.VITE_TMDB_ACCESS_TOKEN}`,
+          },
+          signal,
+        });
+
+        const data = await response.json();
+        if (isMounted) {
+          setData(data);
+          setStatus('success');
+        }
+      } catch (error: unknown) {
+        if (!isMounted) return;
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        setError(error as Error);
+        setStatus('error');
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [url, enabled]);
+
+  return { data, status, error };
+}

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -5,13 +5,19 @@ type Status = 'idle' | 'loading' | 'error' | 'success';
 interface UseFetchResult<T> {
   data: T | null;
   status: Status;
-  error: Error | null;
+  error: ErrorDetail | null;
+}
+
+interface ErrorDetail {
+  message: string;
+  statusCode?: number;
+  statusText?: string;
 }
 
 export function useFetch<T>(url: string, enabled = true): UseFetchResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [status, setStatus] = useState<Status>('idle');
-  const [error, setError] = useState<Error | null>(null);
+  const [error, setError] = useState<ErrorDetail | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
@@ -32,15 +38,43 @@ export function useFetch<T>(url: string, enabled = true): UseFetchResult<T> {
           signal,
         });
 
-        const data = await response.json();
+        if (!response.ok) {
+          const message = `${response.status} ${response.statusText}`;
+          throw {
+            message,
+            statusCode: response.status,
+            statusText: response.statusText,
+          };
+        }
+
+        const data: T = await response.json();
+
         if (isMounted) {
           setData(data);
           setStatus('success');
         }
       } catch (error: unknown) {
         if (!isMounted) return;
+
         if (error instanceof DOMException && error.name === 'AbortError') return;
-        setError(error as Error);
+
+        const errorDetail: ErrorDetail = {
+          message: 'Network error',
+        };
+
+        if (typeof error === 'object' && error !== null) {
+          if ('message' in error && typeof error.message === 'string') {
+            errorDetail.message = error.message;
+          }
+          if ('statusCode' in error && typeof error.statusCode === 'number') {
+            errorDetail.statusCode = error.statusCode;
+          }
+          if ('statusText' in error && typeof error.statusText === 'string') {
+            errorDetail.statusText = error.statusText;
+          }
+        }
+
+        setError(errorDetail);
         setStatus('error');
       }
     };

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -14,29 +14,56 @@ interface UseFetchResult<T> {
   error: ErrorDetail | null;
 }
 
-const fetchCache = new Map<string, unknown>();
+interface CacheItem<T> {
+  data: T;
+  cachedAt: number;
+}
 
-export function useFetch<T>(url: string, enabled = true): UseFetchResult<T> {
+const fetchCache = new Map<string, CacheItem<unknown>>();
+
+export function invalidateCache(url: string) {
+  fetchCache.delete(url);
+}
+
+interface UseFetchOptions {
+  cacheMaxAge?: number;
+}
+
+export function useFetch<T>(
+  url: string,
+  enabled = true,
+  options?: UseFetchOptions
+): UseFetchResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [status, setStatus] = useState<Status>('idle');
   const [error, setError] = useState<ErrorDetail | null>(null);
+  const [refetchTrigger, setRefetchTrigger] = useState(0);
 
   useEffect(() => {
-    if (!enabled) return;
-    if (!url) return;
+    if (!(enabled && url)) return;
 
-    if (fetchCache.has(url)) {
-      setData(fetchCache.get(url) as T);
-      setStatus('success');
-      return;
-    }
+    const cacheMaxAge = options?.cacheMaxAge ?? 1000 * 60 * 5;
+    const now = Date.now();
+    const cacheItem = fetchCache.get(url) as CacheItem<T>;
 
     const controller = new AbortController();
     const signal = controller.signal;
     let isMounted = true;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const scheduleNext = (delay: number) => {
+      if (delay > 0) {
+        timer = setTimeout(() => {
+          if (isMounted) {
+            setRefetchTrigger((prev) => prev + 1);
+          }
+        }, delay);
+      }
+    };
 
     const fetchData = async () => {
       setStatus('loading');
+      setError(null);
       try {
         const response = await fetch(url, {
           method: 'GET',
@@ -48,51 +75,56 @@ export function useFetch<T>(url: string, enabled = true): UseFetchResult<T> {
         });
 
         if (!response.ok) {
-          const message = `${response.status} ${response.statusText}`;
           throw {
-            message,
+            message: `${response.status} ${response.statusText}`,
             statusCode: response.status,
             statusText: response.statusText,
           };
         }
 
-        const data: T = await response.json();
+        const result: T = await response.json();
 
         if (isMounted) {
-          fetchCache.set(url, data);
-          console.log(fetchCache);
-          setData(data);
+          fetchCache.set(url, { data: result, cachedAt: Date.now() });
+          setData(result);
           setStatus('success');
+
+          scheduleNext(cacheMaxAge);
         }
-      } catch (error: unknown) {
-        if (!isMounted || (error instanceof DOMException && error.name === 'AbortError')) return;
+      } catch (err: unknown) {
+        if (!isMounted || (err instanceof DOMException && err.name === 'AbortError')) return;
 
         const errorDetail: ErrorDetail = { message: 'Network error' };
-
-        if (typeof error === 'object' && error !== null) {
-          if ('message' in error && typeof error.message === 'string') {
-            errorDetail.message = error.message;
-          }
-          if ('statusCode' in error && typeof error.statusCode === 'number') {
-            errorDetail.statusCode = error.statusCode;
-          }
-          if ('statusText' in error && typeof error.statusText === 'string') {
-            errorDetail.statusText = error.statusText;
-          }
+        if (typeof err === 'object' && err !== null) {
+          if ('message' in err && typeof err.message === 'string')
+            errorDetail.message = err.message;
+          if ('statusCode' in err && typeof err.statusCode === 'number')
+            errorDetail.statusCode = err.statusCode;
+          if ('statusText' in err && typeof err.statusText === 'string')
+            errorDetail.statusText = err.statusText;
         }
-
         setError(errorDetail);
         setStatus('error');
       }
     };
 
-    fetchData();
+    if (cacheItem && now - cacheItem.cachedAt < cacheMaxAge) {
+      setData(cacheItem.data);
+      setStatus('success');
+      setError(null);
+
+      const timeUntilExpiry = cacheMaxAge - (now - cacheItem.cachedAt);
+      scheduleNext(timeUntilExpiry);
+    } else {
+      fetchData();
+    }
 
     return () => {
       isMounted = false;
       controller.abort();
+      if (timer) clearTimeout(timer);
     };
-  }, [url, enabled]);
+  }, [url, enabled, options?.cacheMaxAge, refetchTrigger]);
 
   return { data, status, error };
 }

--- a/src/hooks/useMovies.ts
+++ b/src/hooks/useMovies.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useApi } from './useApi';
+import * as movieApi from '../api/movie';
+
+interface UseMoviesOptions {
+  enabled?: boolean;
+  page?: number;
+  language?: string;
+}
+
+interface UseMovieDetailOptions {
+  enabled?: boolean;
+  language?: string;
+}
+
+/**
+ * 인기 영화 목록 조회 훅
+ */
+export function usePopularMovies(options: UseMoviesOptions = {}) {
+  const { enabled = true, page = 1, language = 'ko-KR' } = options;
+  
+  const apiCall = useCallback(
+    () => movieApi.getPopularMovies({ page, language }),
+    [page, language]
+  );
+  
+  return useApi(apiCall, `popular-movies-${page}-${language}`, { enabled });
+}
+
+/**
+ * 영화 상세 정보 조회 훅
+ */
+export function useMovieDetail(movieId: number, options: UseMovieDetailOptions = {}) {
+  const { enabled = true, language = 'ko-KR' } = options;
+  
+  const apiCall = useCallback(
+    () => movieApi.getMovieDetail(movieId, language),
+    [movieId, language]
+  );
+  
+  return useApi(apiCall, `movie-detail-${movieId}-${language}`, { 
+    enabled: enabled && !!movieId,
+    staleTime: 10 * 60 * 1000, // 10분 캐싱
+  });
+} 

--- a/src/pages/MovieDetail.tsx
+++ b/src/pages/MovieDetail.tsx
@@ -7,18 +7,23 @@ import {
   PlayIcon,
 } from '@heroicons/react/24/solid';
 import { Button } from '@/components/ui/button';
-import type { MovieDetail } from '@/types/movie';
 import MovieDetailSkeleton from '@/components/MovieDetail/MovieDetailSkeleton';
-import { useFetch } from '@/hooks/useFetch';
-import { api } from '@/api/api';
+import { useMovieDetail } from '@/hooks/useMovies';
 
 export default function MovieDetail() {
   const navigate = useNavigate();
   const { id } = useParams();
-  const { data: movie, status } = useFetch<MovieDetail>(api.detail(id!), !!id);
+  const movieId = id ? parseInt(id, 10) : 0;
+  
+  // 새로운 훅 사용
+  const { data: movie, isLoading, isError } = useMovieDetail(movieId, {
+    enabled: !!movieId,
+  });
 
-  if (status === 'loading') return <MovieDetailSkeleton />;
-  if (status === 'error') return <p>영화 정보를 불러오지 못했습니다.</p>;
+  console.log('🎬 MovieDetail rendered:', { movieId, movie, isLoading, isError });
+
+  if (isLoading) return <MovieDetailSkeleton />;
+  if (isError) return <p>영화 정보를 불러오지 못했습니다.</p>;
   if (!movie) return <p className="text-lg">영화 정보를 찾을 수 없습니다.</p>;
 
   return (

--- a/src/pages/MovieDetail.tsx
+++ b/src/pages/MovieDetail.tsx
@@ -1,5 +1,4 @@
 import { useNavigate, useParams } from 'react-router-dom';
-import { useState, useEffect } from 'react';
 import {
   ChevronLeftIcon,
   CalendarIcon,
@@ -10,55 +9,13 @@ import {
 import { Button } from '@/components/ui/button';
 import type { MovieDetail } from '@/types/movie';
 import MovieDetailSkeleton from '@/components/MovieDetail/MovieDetailSkeleton';
+import { useFetch } from '@/hooks/useFetch';
+import { api } from '@/api/api';
 
 export default function MovieDetail() {
   const navigate = useNavigate();
   const { id } = useParams();
-  const [movie, setMovie] = useState<MovieDetail | null>(null);
-  const [status, setStatus] = useState<'idle' | 'loading' | 'error' | 'success'>('idle');
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const signal = controller.signal;
-
-    let isMounted = true;
-
-    const fetchData = async () => {
-      setStatus('loading');
-
-      try {
-        const options = {
-          method: 'GET',
-          headers: {
-            accept: 'application/json',
-            Authorization: `Bearer ${import.meta.env.VITE_TMDB_ACCESS_TOKEN}`,
-          },
-          signal,
-        };
-
-        const res = await fetch(`https://api.themoviedb.org/3/movie/${id}?language=ko-KR`, options);
-
-        const data = await res.json();
-
-        if (isMounted) {
-          setMovie(data);
-          setStatus('success');
-        }
-      } catch (err) {
-        if (err instanceof Error && err.name !== 'AbortError') {
-          console.error(err);
-          setStatus('error');
-        }
-      }
-    };
-
-    fetchData();
-
-    return () => {
-      isMounted = false;
-      controller.abort();
-    };
-  }, [id]);
+  const { data: movie, status } = useFetch<MovieDetail>(api.detail(id!), !!id);
 
   if (status === 'loading') return <MovieDetailSkeleton />;
   if (status === 'error') return <p>영화 정보를 불러오지 못했습니다.</p>;

--- a/src/pages/MovieDetail.tsx
+++ b/src/pages/MovieDetail.tsx
@@ -1,4 +1,5 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import {
   ChevronLeftIcon,
   CalendarIcon,
@@ -7,30 +8,35 @@ import {
   PlayIcon,
 } from '@heroicons/react/24/solid';
 import { Button } from '@/components/ui/button';
-
-const dummyMovie = {
-  id: 1,
-  title: '아바타: 물의 길',
-  original_title: 'Avatar: The Way of Water',
-  poster_path: 'https://image.tmdb.org/t/p/w500/t6HIqrRAclMCA60NsSmeqe9RmNV.jpg',
-  backdrop_path: 'https://image.tmdb.org/t/p/w1280/s16H6tpK2utvwDtzZ8Qy4qm5Emw.jpg',
-  vote_average: 8.2,
-  release_date: '2022-12-16',
-  runtime: 192,
-  overview: '설리 가족의 이야기와 그들을 따라다니는 문제, 생존을 위한 전투를 그린 서사.',
-  genres: [{ name: '모험' }, { name: 'SF' }, { name: '액션' }],
-};
+import type { MovieDetail } from '@/types/Movie';
 
 export default function MovieDetail() {
   const navigate = useNavigate();
+  const { id } = useParams();
+  const [movie, setMovie] = useState<MovieDetail | null>(null);
 
-  const movie = dummyMovie;
+  useEffect(() => {
+    const options = {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        Authorization: `Bearer ${import.meta.env.VITE_TMDB_ACCESS_TOKEN}`,
+      },
+    };
+
+    fetch(`https://api.themoviedb.org/3/movie/${id}?language=ko-KR`, options)
+      .then((res) => res.json())
+      .then((res) => setMovie(res))
+      .catch((err) => console.error(err));
+  }, [id]);
+
+  if (!movie) return <div>Loading...</div>;
 
   return (
     <div className="bg-[#0d253f] text-white min-h-screen">
       <div className="relative h-[60vh] w-full overflow-hidden">
         <img
-          src={movie.backdrop_path}
+          src={`https://image.tmdb.org/t/p/w500${movie.backdrop_path}`}
           alt="backdrop"
           className="w-full h-full object-cover opacity-30"
         />
@@ -45,7 +51,7 @@ export default function MovieDetail() {
         <div className="absolute inset-0 flex items-end p-8 bg-gradient-to-t from-[#0d253f] to-transparent">
           <div className="flex gap-8 max-w-6xl w-full mx-auto items-end">
             <img
-              src={movie.poster_path}
+              src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
               alt={movie.title}
               className="w-40 sm:w-48 rounded-lg shadow-lg border-2 border-white/10"
             />
@@ -63,13 +69,13 @@ export default function MovieDetail() {
                 </div>
                 <div className="flex items-center gap-1 text-yellow-400">
                   <StarIcon className="w-4 h-4" />
-                  <span>{movie.vote_average}</span>
+                  <span>{movie.vote_average.toFixed(1)}</span>
                 </div>
               </div>
               <div className="mt-3 flex gap-2 flex-wrap">
-                {movie.genres.map((g, i) => (
-                  <span key={i} className="px-3 py-1 bg-teal-700/60 text-sm rounded-full">
-                    {g.name}
+                {movie.genres?.map((genre) => (
+                  <span key={genre.id} className="px-3 py-1 bg-teal-700/60 text-sm rounded-full">
+                    {genre.name}
                   </span>
                 ))}
               </div>

--- a/src/pages/MovieList.tsx
+++ b/src/pages/MovieList.tsx
@@ -1,56 +1,10 @@
-import { useState, useEffect } from 'react';
 import MovieListView from '@/components/MovieList/MovieListView';
+import { useFetch } from '@/hooks/useFetch';
+import { api } from '@/api/api';
 import type { Movie } from '@/types/movie';
 
 export default function MovieList() {
-  const [movieList, setMovieList] = useState<Movie[]>([]);
-  const [status, setStatus] = useState<'idle' | 'loading' | 'error' | 'success'>('idle');
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const signal = controller.signal;
-
-    let isMounted = true;
-
-    const fetchData = async () => {
-      setStatus('loading');
-
-      try {
-        const options = {
-          method: 'GET',
-          headers: {
-            accept: 'application/json',
-            Authorization: `Bearer ${import.meta.env.VITE_TMDB_ACCESS_TOKEN}`,
-          },
-          signal,
-        };
-
-        const res = await fetch(
-          'https://api.themoviedb.org/3/movie/popular?language=ko-KR&page=1',
-          options
-        );
-
-        const data = await res.json();
-
-        if (isMounted) {
-          setMovieList(data.results);
-          setStatus('success');
-        }
-      } catch (err) {
-        if (err instanceof Error && err.name !== 'AbortError') {
-          console.error(err);
-          setStatus('error');
-        }
-      }
-    };
-
-    fetchData();
-
-    return () => {
-      isMounted = false;
-      controller.abort();
-    };
-  }, []);
+  const { data: movieList, status } = useFetch<{ results: Movie[] }>(api.popular(1));
 
   return (
     <div className="bg-[#0d253f] min-h-screen text-white">
@@ -62,7 +16,7 @@ export default function MovieList() {
 
       <main className="max-w-7xl mx-auto py-10">
         <h2 className="text-2xl font-semibold mb-6">인기 영화</h2>
-        <MovieListView status={status} movieList={movieList} />
+        <MovieListView status={status} movieList={movieList?.results || []} />
       </main>
     </div>
   );

--- a/src/pages/MovieList.tsx
+++ b/src/pages/MovieList.tsx
@@ -1,10 +1,13 @@
 import MovieListView from '@/components/MovieList/MovieListView';
-import { useFetch } from '@/hooks/useFetch';
-import { api } from '@/api/api';
-import type { Movie } from '@/types/movie';
+import { usePopularMovies } from '@/hooks/useMovies';
 
 export default function MovieList() {
-  const { data: movieList, status } = useFetch<{ results: Movie[] }>(api.popular(1));
+  const { data: movieList, isLoading, isError } = usePopularMovies({ page: 1 });
+
+  console.log('🎬 MovieList rendered:', { movieList, isLoading, isError });
+
+  // 기존 status 형태로 변환 (MovieListView 호환성 위해)
+  const status = isLoading ? 'loading' : isError ? 'error' : 'success';
 
   return (
     <div className="bg-[#0d253f] min-h-screen text-white">
@@ -16,7 +19,7 @@ export default function MovieList() {
 
       <main className="max-w-7xl mx-auto py-10">
         <h2 className="text-2xl font-semibold mb-6">인기 영화</h2>
-        <MovieListView status={status} movieList={movieList?.results || []} />
+        <MovieListView status={status} movieList={movieList || []} />
       </main>
     </div>
   );

--- a/src/pages/MovieList.tsx
+++ b/src/pages/MovieList.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
-import MovieCard from '@/components/MovieCard';
-import type { Movie } from '@/types/Movie';
+import MovieListView from '@/components/MovieList/MovieListView';
+import type { Movie } from '@/types/movie';
 
 export default function MovieList() {
   const [movieList, setMovieList] = useState<Movie[]>([]);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error' | 'success'>('idle');
 
   useEffect(() => {
     const controller = new AbortController();
@@ -12,6 +13,8 @@ export default function MovieList() {
     let isMounted = true;
 
     const fetchData = async () => {
+      setStatus('loading');
+
       try {
         const options = {
           method: 'GET',
@@ -31,10 +34,12 @@ export default function MovieList() {
 
         if (isMounted) {
           setMovieList(data.results);
+          setStatus('success');
         }
       } catch (err) {
         if (err instanceof Error && err.name !== 'AbortError') {
           console.error(err);
+          setStatus('error');
         }
       }
     };
@@ -57,11 +62,7 @@ export default function MovieList() {
 
       <main className="max-w-7xl mx-auto py-10">
         <h2 className="text-2xl font-semibold mb-6">인기 영화</h2>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
-          {movieList.map((movie) => (
-            <MovieCard key={movie.id} movie={movie} />
-          ))}
-        </div>
+        <MovieListView status={status} movieList={movieList} />
       </main>
     </div>
   );

--- a/src/pages/MovieList.tsx
+++ b/src/pages/MovieList.tsx
@@ -1,16 +1,24 @@
+import { useState, useEffect } from 'react';
 import MovieCard from '@/components/MovieCard';
-
-const dummyList = Array.from({ length: 12 }, (_, i) => ({
-  id: i + 1,
-  title: `Movie Title ${i + 1}`,
-  original_title: `Original Title ${i + 1}`,
-  poster_path: `https://image.tmdb.org/t/p/w500/62HCnUTziyWcpDaBO2i1DX17ljH.jpg`,
-  vote_average: 7.5 + (i % 3),
-  release_date: `202${i % 10}-01-01`,
-}));
+import type { Movie } from '@/types/Movie';
 
 export default function MovieList() {
-  
+  const [movieList, setMovieList] = useState<Movie[]>([]);
+
+  useEffect(() => {
+    const options = {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        Authorization: `Bearer ${import.meta.env.VITE_TMDB_ACCESS_TOKEN}`,
+      },
+    };
+
+    fetch('https://api.themoviedb.org/3/movie/popular?language=ko-KR&page=1', options)
+      .then((res) => res.json())
+      .then((res) => setMovieList(res.results))
+      .catch((err) => console.error(err));
+  }, []);
 
   return (
     <div className="bg-[#0d253f] min-h-screen text-white">
@@ -23,7 +31,7 @@ export default function MovieList() {
       <main className="max-w-7xl mx-auto py-10">
         <h2 className="text-2xl font-semibold mb-6">인기 영화</h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
-          {dummyList.map((movie) => (
+          {movieList.map((movie) => (
             <MovieCard key={movie.id} movie={movie} />
           ))}
         </div>

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -6,3 +6,16 @@ export interface Movie {
   vote_average: number;
   release_date: string;
 }
+
+export interface MovieDetail extends Movie {
+  backdrop_path: string | null;
+  poster_path: string | null;
+  runtime: number;
+  genres: genre[];
+  overview: string;
+}
+
+interface genre {
+  id: number;
+  name: string;
+}

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -1,0 +1,8 @@
+export interface Movie {
+  id: number;
+  title: string;
+  original_title: string;
+  poster_path: string | null;
+  vote_average: number;
+  release_date: string;
+}


### PR DESCRIPTION
### 구현 사항

1. **`useFetch` 커스텀 훅 구현**
- API 요청에 대한 상태를 status별로 정리했습니다.

- 요청 실패 시에는 HTTP 응답 정보를 기반으로 에러 메시지, 상태 코드, 상태 텍스트 등을 처리하고 네트워크 오류 등의 상황에 대처할 수 있도록 했습니다. 

- AbortController를 도입하여 비동기 요청 도중에 컴포넌트가 언마운트되었을 때 fetch 요청을 중단하도록 했습니다.

- isMounted 플래그를 사용하여 요청 중간에 컴포넌트가 언마운트되는 경우에도 상태 업데이트를 시도하지 않도록 방지했습니다.

2. **데이터 캐싱 기능 추가**
- 동일한 URL로 요청한 데이터를 캐싱하는 구조를 추가했습니다.

3. **TTL(캐시 유효 시간) 기반 자동 갱신**
- 캐시된 데이터가 최신 데이터로 반영되도록 하기 위해 cacheMaxAge 옵션을 통해 외부에서 시간을 지정할 수 있게 했습니다.

- 내부적으로는 setTimeout을 사용해서 만료 시점을 계산하고 자동으로 재요청을 트리거하는 타이머를 만들었습니다.


### 어려운 점

- 현재 useFetch는 데이터 페칭 과정 전체를 내부에서 직접 담당하고 있는데 데이터 페칭과 상태를 추적하는 로직이 함께 았습니다..
이상적으로는 데이터 페칭 로직 자체는 외부에서 주입하고 훅은 그 실행 결과의 상태만 추적하는 구조로 분리하고 싶은데 이걸 어떻게 설계할지 판단이 잘 안 섭니다.

- 수동으로 데이터를 다시 요청할 수 있도록 refetch 함수를 구현해 외부로 꺼내야하는데 현재 구조에서 훅 내부 상태와 타이머 로직이랑 엮여 있어서 자연스럽게 분리하기가 어렵네요. 

- useEffect 내에서 의존성이 점점 늘어나면서 상태 변화의 흐름을 따라가기가 점점 어려워지네요. 아무래도 이 부분을 좀 더 머리 속으로 정리하는 시간이 필요할 거 같습니다.